### PR TITLE
Fix NoRegionError

### DIFF
--- a/crhelper/resource_helper.py
+++ b/crhelper/resource_helper.py
@@ -26,7 +26,7 @@ FAILED = 'FAILED'
 
 class CfnResource(object):
 
-    def __init__(self, json_logging=False, log_level='DEBUG', boto_level='ERROR', polling_interval=2):
+    def __init__(self, json_logging=False, log_level='DEBUG', boto_level='ERROR', polling_interval=2, region_name='us-east-1'):
         self._create_func = None
         self._update_func = None
         self._delete_func = None
@@ -51,11 +51,12 @@ class CfnResource(object):
         self._context = None
         self._response_url = ""
         self._sam_local = os.getenv('AWS_SAM_LOCAL')
+        self._region_name = os.getenv('AWS_DEFAULT_REGION', region_name)
         try:
             if not self._sam_local:
-                self._lambda_client = boto3.client('lambda')
-                self._events_client = boto3.client('events')
-                self._logs_client = boto3.client('logs')
+                self._lambda_client = boto3.client('lambda', region_name=self._region_name)
+                self._events_client = boto3.client('events', region_name=self._region_name)
+                self._logs_client = boto3.client('logs', region_name=self._region_name)
             if json_logging:
                 log_helper.setup(log_level, boto_level=boto_level, RequestType='ContainerInit')
             else:

--- a/crhelper/resource_helper.py
+++ b/crhelper/resource_helper.py
@@ -26,7 +26,7 @@ FAILED = 'FAILED'
 
 class CfnResource(object):
 
-    def __init__(self, json_logging=False, log_level='DEBUG', boto_level='ERROR', polling_interval=2, region_name='us-east-1'):
+    def __init__(self, json_logging=False, log_level='DEBUG', boto_level='ERROR', polling_interval=2):
         self._create_func = None
         self._update_func = None
         self._delete_func = None
@@ -51,12 +51,12 @@ class CfnResource(object):
         self._context = None
         self._response_url = ""
         self._sam_local = os.getenv('AWS_SAM_LOCAL')
-        self._region_name = os.getenv('AWS_DEFAULT_REGION', region_name)
+        self._region = os.getenv('AWS_REGION')
         try:
             if not self._sam_local:
-                self._lambda_client = boto3.client('lambda', region_name=self._region_name)
-                self._events_client = boto3.client('events', region_name=self._region_name)
-                self._logs_client = boto3.client('logs', region_name=self._region_name)
+                self._lambda_client = boto3.client('lambda', region_name=self._region)
+                self._events_client = boto3.client('events', region_name=self._region)
+                self._logs_client = boto3.client('logs', region_name=self._region)
             if json_logging:
                 log_helper.setup(log_level, boto_level=boto_level, RequestType='ContainerInit')
             else:

--- a/tests/test_resource_helper.py
+++ b/tests/test_resource_helper.py
@@ -51,7 +51,9 @@ class TestCfnResource(unittest.TestCase):
             crhelper.resource_helper.CfnResource()
         mock_method.assert_called_once_with('DEBUG', boto_level='ERROR', formatter_cls=None)
 
-        crhelper.resource_helper.CfnResource(json_logging=True)
+        with support.EnvironmentVarGuard() as environ: 
+            environ.set('AWS_REGION', 'us-east-1')
+            crhelper.resource_helper.CfnResource(json_logging=True)
         mock_method.assert_called_with('DEBUG', boto_level='ERROR', RequestType='ContainerInit')
 
     @patch('crhelper.log_helper.setup', return_value=None)

--- a/tests/test_resource_helper.py
+++ b/tests/test_resource_helper.py
@@ -48,7 +48,7 @@ class TestCfnResource(unittest.TestCase):
     def test_init(self, mock_method):
         with support.EnvironmentVarGuard() as environ: 
             environ.set('AWS_REGION', 'us-east-1')
-        crhelper.resource_helper.CfnResource()
+            crhelper.resource_helper.CfnResource()
         mock_method.assert_called_once_with('DEBUG', boto_level='ERROR', formatter_cls=None)
 
         crhelper.resource_helper.CfnResource(json_logging=True)

--- a/tests/test_resource_helper.py
+++ b/tests/test_resource_helper.py
@@ -1,4 +1,5 @@
 import crhelper
+from test import support
 import unittest
 from unittest.mock import patch, Mock
 import threading
@@ -45,6 +46,8 @@ class TestCfnResource(unittest.TestCase):
     @patch('crhelper.log_helper.setup', return_value=None)
     @patch('crhelper.resource_helper.CfnResource._set_timeout', Mock())
     def test_init(self, mock_method):
+        with support.EnvironmentVarGuard() as environ: 
+            environ.set('AWS_REGION', 'us-east-1')
         crhelper.resource_helper.CfnResource()
         mock_method.assert_called_once_with('DEBUG', boto_level='ERROR', formatter_cls=None)
 
@@ -268,7 +271,9 @@ class TestCfnResource(unittest.TestCase):
     @patch('crhelper.resource_helper.CfnResource._send', Mock())
     @patch('crhelper.resource_helper.CfnResource._set_timeout', Mock())
     def test_remove_polling(self):
-        c = crhelper.resource_helper.CfnResource()
+        with support.EnvironmentVarGuard() as environ: 
+            environ.set('AWS_REGION', 'us-east-1')
+            c = crhelper.resource_helper.CfnResource()
         c._context = MockContext()
 
         c._events_client.remove_targets = Mock()
@@ -296,7 +301,9 @@ class TestCfnResource(unittest.TestCase):
     @patch('crhelper.resource_helper.CfnResource._send', Mock())
     @patch('crhelper.resource_helper.CfnResource._set_timeout', Mock())
     def test_setup_polling(self):
-        c = crhelper.resource_helper.CfnResource()
+        with support.EnvironmentVarGuard() as environ: 
+            environ.set('AWS_REGION', 'us-east-1')
+            c = crhelper.resource_helper.CfnResource()
         c._context = MockContext()
         c._event = test_events["Update"]
         c._lambda_client.add_permission = Mock()


### PR DESCRIPTION
*Description of changes:*
Support custom `region_name`. 

Currently, the implementation depends on the `AWS_DEFAULT_REGION` envvar. If the envvar fails to exists, we get the errror `botocore.exceptions.NoRegionError: You must specify a region.`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
