### PR TITLE
Generate PhysicalResourceId when Status == SUCCESS

### DIFF
--- a/crhelper/resource_helper.py
+++ b/crhelper/resource_helper.py
@@ -151,11 +151,10 @@ class CfnResource(object):
             self.PhysicalResourceId = event['PhysicalResourceId']
         # Generate a physical id if none is provided
         elif not self.PhysicalResourceId or self.PhysicalResourceId is True:
-            if "PhysicalResourceId" in event.keys():
-                logger.info("PhysicalResourceId present in event, Using that for response")
-            logger.info("No physical resource id returned, generating one...")
-            self.PhysicalResourceId = event['StackId'].split('/')[1] + '_' + event[
-                'LogicalResourceId'] + '_' + self._rand_string(8)
+            if self.Status == SUCCESS:
+                logger.info("No physical resource id returned, generating one...")
+                self.PhysicalResourceId = event['StackId'].split('/')[1] + '_' + event[
+                    'LogicalResourceId'] + '_' + self._rand_string(8)
         self._send()
 
     def _poll_enabled(self):

--- a/tests/test_resource_helper.py
+++ b/tests/test_resource_helper.py
@@ -170,6 +170,7 @@ class TestCfnResource(unittest.TestCase):
     def test_cfn_response(self):
         c = crhelper.resource_helper.CfnResource()
         event = test_events['Create']
+        c.Status = SUCCESS
         c._send = Mock()
 
         orig_pid = c.PhysicalResourceId

--- a/tests/test_resource_helper.py
+++ b/tests/test_resource_helper.py
@@ -170,7 +170,7 @@ class TestCfnResource(unittest.TestCase):
     def test_cfn_response(self):
         c = crhelper.resource_helper.CfnResource()
         event = test_events['Create']
-        c.Status = SUCCESS
+        c.Status = 'SUCCESS'
         c._send = Mock()
 
         orig_pid = c.PhysicalResourceId


### PR DESCRIPTION
Proposed changed to fix issue #7 

*Description of changes:*

When failing to create the custom resource, crherlper generates a PhysicalResourceId lures Cloudformation into thinking a resource was created. Only generate and return a PhysicalResourceId when 1) there is none 2) the response is successful

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
