### PR TITLE
allow only defining needed handlers

### DIFF
--- a/crhelper/resource_helper.py
+++ b/crhelper/resource_helper.py
@@ -187,7 +187,7 @@ class CfnResource(object):
 
     def _wrap_function(self, func):
         try:
-            self.PhysicalResourceId = func(self._event, self._context)
+            self.PhysicalResourceId = func(self._event, self._context) if func else ''
         except Exception as e:
             logger.error(str(e), exc_info=True)
             self.Reason = str(e)


### PR DESCRIPTION
only define the handlers you need, if no handler is defined the op will return success.

Currently leaving out a handler for `Create`/`Update`/`Delete` results in:

```
Traceback (most recent call last):
  File "/opt/python/crhelper/resource_helper.py", line 190, in _wrap_function
    self.PhysicalResourceId = func(self._event, self._context)
TypeError: 'NoneType' object is not callable
```

After this patch the call will return success, either generating an id, or (if present) using the one supplied in the event.