### PR TITLE
Fix systax error resource_helper.py

### DIFF
--- a/crhelper/resource_helper.py
+++ b/crhelper/resource_helper.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 TODO:
 * Async mode – take a wait condition handle as an input, increases max timeout to 12 hours


### PR DESCRIPTION
Using custom-resource-helper in lambda with python2.7 I was not able to
run the Lambda Function for custom resource due to the below error:

```
Syntax error in module 'eventbus_custom_resource': Non-ASCII character '\xe2'
in file /var/task/crhelper/resource_helper.py on line 4, but no encoding
 declared; see http://python.org/dev/peps/pep-0263/
 for details (resource_helper.py, line 3)
```
*Description of changes:*
To fix this, encoding was added to the begin of the file

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
