### PR TITLE
Wrap code comments so they're readable on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,26 +63,27 @@ def create(event, context):
 @helper.update
 def update(event, context):
     logger.info("Got Update")
-    # If the update resulted in a new resource being created, return an id for the new resource. CloudFormation will send
-    # a delete event with the old id when stack update completes
+    # If the update resulted in a new resource being created, return an id for the new resource. 
+    # CloudFormation will send a delete event with the old id when stack update completes
 
 
 @helper.delete
 def delete(event, context):
     logger.info("Got Delete")
-    # Delete never returns anything. Should not fail if the underlying resources are already deleted. Desired state.
+    # Delete never returns anything. Should not fail if the underlying resources are already deleted.
+    # Desired state.
 
 
 @helper.poll_create
 def poll_create(event, context):
     logger.info("Got create poll")
-    # Return a resource id or True to indicate that creation is complete. if True is returned an id will be generated
+    # Return a resource id or True to indicate that creation is complete. if True is returned an id 
+    # will be generated
     return True
 
 
 def handler(event, context):
     helper(event, context)
-
 ```
 
 ### Polling


### PR DESCRIPTION
The code comments are longer than what displays on GitHub. This wraps them so it's readable without scrolling


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
