### PR TITLE
Add requests dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     author_email="jmmccon@amazon.com",
     license="Apache2",
     packages=find_packages(),
+    install_requires=["requests"],
     tests_require=["boto3", "requests"],
     test_suite="tests",
     classifiers=[


### PR DESCRIPTION
Currently when installing the package through pip, requests isn't installed as a dependency. Just added it to install_requires

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
