### PR TITLE
Split physical resource id generation into seperate function

### DIFF
--- a/crhelper/resource_helper.py
+++ b/crhelper/resource_helper.py
@@ -145,6 +145,13 @@ class CfnResource(object):
             self._remove_polling()
             self._send_response = True
 
+    def generate_physical_id(self, event):
+        return '_'.join([
+            event['StackId'],
+            event['LogicalResourceId'],
+            self._rand_string(8)
+        ])
+
     def _cfn_response(self, event):
         # Use existing PhysicalResourceId if it's in the event and no ID was set
         if not self.PhysicalResourceId and "PhysicalResourceId" in event.keys():
@@ -155,8 +162,7 @@ class CfnResource(object):
             if "PhysicalResourceId" in event.keys():
                 logger.info("PhysicalResourceId present in event, Using that for response")
             logger.info("No physical resource id returned, generating one...")
-            self.PhysicalResourceId = event['StackId'].split('/')[1] + '_' + event[
-                'LogicalResourceId'] + '_' + self._rand_string(8)
+            self.PhysicalResourceId = self.generate_physical_id(event)
         self._send()
 
     def _poll_enabled(self):

--- a/crhelper/resource_helper.py
+++ b/crhelper/resource_helper.py
@@ -159,8 +159,6 @@ class CfnResource(object):
             self.PhysicalResourceId = event['PhysicalResourceId']
         # Generate a physical id if none is provided
         elif not self.PhysicalResourceId or self.PhysicalResourceId is True:
-            if "PhysicalResourceId" in event.keys():
-                logger.info("PhysicalResourceId present in event, Using that for response")
             logger.info("No physical resource id returned, generating one...")
             self.PhysicalResourceId = self.generate_physical_id(event)
         self._send()

--- a/crhelper/resource_helper.py
+++ b/crhelper/resource_helper.py
@@ -147,7 +147,7 @@ class CfnResource(object):
 
     def generate_physical_id(self, event):
         return '_'.join([
-            event['StackId'],
+            event['StackId'].split('/')[1],
             event['LogicalResourceId'],
             self._rand_string(8)
         ])


### PR DESCRIPTION
Split resource generation into reusable function. This enables generating a resource id during the creation function without having to write custom id generation code.

The use case i had for this was creating a resource and tagging it with the physical resource id.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
