### PR TITLE
Add boolean return to _crhelper_init for _init_failed

### DIFF
--- a/crhelper/resource_helper.py
+++ b/crhelper/resource_helper.py
@@ -71,7 +71,8 @@ class CfnResource(object):
         try:
             self._log_setup(event, context)
             logger.debug(event)
-            self._crhelper_init(event, context)
+            if not self._crhelper_init(event, context):
+                return
             # Check for polling functions
             if self._poll_enabled() and self._sam_local:
                 logger.info("Skipping poller functionality, as this is a local invocation")
@@ -129,9 +130,11 @@ class CfnResource(object):
         if self._timer:
             self._timer.cancel()
         if self._init_failed:
-            return self._send(FAILED, str(self._init_failed))
+            self._send(FAILED, str(self._init_failed))
+            return False
         self._set_timeout()
         self._wrap_function(self._get_func())
+        return True
 
     def _polling_init(self, event):
         # Setup polling on initial request


### PR DESCRIPTION
*Description of changes:*

When `_init_failed` is `True` inside `_crhelper_init` the code returns early, but then continues down the `__call__` function, resulting in still hitting `_cfn_response`. This causes **two** `_send` calls to be made. The original `FAILED` call and also a **successful** one.

This change adds a boolean return to `_crhelper_init` function and will return `False` when `_init_failed` is set. We then check the return of `_crhelper_init` in `__call__` and return immediately, resulting in just the single `FAILED` call to `_send`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.