### PR TITLE
Remove tests folder from package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     author="Jay McConnell",
     author_email="jmmccon@amazon.com",
     license="Apache2",
-    packages=find_packages(),
+    packages=find_packages(exclude=("tests", "tests.*",)),
     install_requires=[],
     tests_require=["boto3"],
     test_suite="tests",


### PR DESCRIPTION
*Description of changes:*
When installing `crhelper` via `pip` there is always the `tests` folder attached, which shouldn't be added to a package in general.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
