### PR TITLE
add ability to turn off cert verification/use custom CA bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 # Initialise the helper, all inputs are optional, this example shows the defaults
-helper = CfnResource(json_logging=False, log_level='DEBUG', boto_level='CRITICAL', sleep_on_delete=120, verify=True)
+helper = CfnResource(json_logging=False, log_level='DEBUG', boto_level='CRITICAL', sleep_on_delete=120, ssl_verify=True)
 
 try:
     ## Init code goes here
@@ -122,6 +122,10 @@ attached to the function's IAM role:
   ]
 }
 ```
+### Certificate Verification
+To turn off certification verification, or to use a custom CA bundle path, override the `ssl_verify` argument with the appropriate values.  These can be either:
+* `False` - do not validate SSL certificates. SSL will still be used, but SSL certificates will not be verified.
+* `path/to/cert/bundle.pem` - A filename of the CA cert bundle to uses. You can specify this argument if you want to use a different CA cert bundle than the one used by botocore.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 # Initialise the helper, all inputs are optional, this example shows the defaults
-helper = CfnResource(json_logging=False, log_level='DEBUG', boto_level='CRITICAL', sleep_on_delete=120)
+helper = CfnResource(json_logging=False, log_level='DEBUG', boto_level='CRITICAL', sleep_on_delete=120, verify=True)
 
 try:
     ## Init code goes here

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ attached to the function's IAM role:
 }
 ```
 ### Certificate Verification
-To turn off certification verification, or to use a custom CA bundle path, override the `ssl_verify` argument with the appropriate values.  These can be either:
+To turn off certification verification, or to use a custom CA bundle path for the underlying boto3 clients used by this library, override the `ssl_verify` argument with the appropriate values.  These can be either:
 * `False` - do not validate SSL certificates. SSL will still be used, but SSL certificates will not be verified.
 * `path/to/cert/bundle.pem` - A filename of the CA cert bundle to uses. You can specify this argument if you want to use a different CA cert bundle than the one used by botocore.
 

--- a/crhelper/resource_helper.py
+++ b/crhelper/resource_helper.py
@@ -27,7 +27,7 @@ FAILED = 'FAILED'
 
 class CfnResource(object):
 
-    def __init__(self, json_logging=False, log_level='DEBUG', boto_level='ERROR', polling_interval=2, sleep_on_delete=120):
+    def __init__(self, json_logging=False, log_level='DEBUG', boto_level='ERROR', polling_interval=2, sleep_on_delete=120, verify=True):
         self._sleep_on_delete = sleep_on_delete
         self._create_func = None
         self._update_func = None
@@ -55,11 +55,12 @@ class CfnResource(object):
         self._response_url = ""
         self._sam_local = os.getenv('AWS_SAM_LOCAL')
         self._region = os.getenv('AWS_REGION')
+        self._verify = verify
         try:
             if not self._sam_local:
-                self._lambda_client = boto3.client('lambda', region_name=self._region)
-                self._events_client = boto3.client('events', region_name=self._region)
-                self._logs_client = boto3.client('logs', region_name=self._region)
+                self._lambda_client = boto3.client('lambda', region_name=self._region, verify=self._verify)
+                self._events_client = boto3.client('events', region_name=self._region, verify=self._verify)
+                self._logs_client = boto3.client('logs', region_name=self._region, verify=self._verify)
             if json_logging:
                 log_helper.setup(log_level, boto_level=boto_level, RequestType='ContainerInit')
             else:

--- a/crhelper/resource_helper.py
+++ b/crhelper/resource_helper.py
@@ -27,7 +27,7 @@ FAILED = 'FAILED'
 
 class CfnResource(object):
 
-    def __init__(self, json_logging=False, log_level='DEBUG', boto_level='ERROR', polling_interval=2, sleep_on_delete=120, verify=True):
+    def __init__(self, json_logging=False, log_level='DEBUG', boto_level='ERROR', polling_interval=2, sleep_on_delete=120, ssl_verify=True):
         self._sleep_on_delete = sleep_on_delete
         self._create_func = None
         self._update_func = None
@@ -55,12 +55,12 @@ class CfnResource(object):
         self._response_url = ""
         self._sam_local = os.getenv('AWS_SAM_LOCAL')
         self._region = os.getenv('AWS_REGION')
-        self._verify = verify
+        self._ssl_verify = ssl_verify
         try:
             if not self._sam_local:
-                self._lambda_client = boto3.client('lambda', region_name=self._region, verify=self._verify)
-                self._events_client = boto3.client('events', region_name=self._region, verify=self._verify)
-                self._logs_client = boto3.client('logs', region_name=self._region, verify=self._verify)
+                self._lambda_client = boto3.client('lambda', region_name=self._region, verify=self._ssl_verify)
+                self._events_client = boto3.client('events', region_name=self._region, verify=self._ssl_verify)
+                self._logs_client = boto3.client('logs', region_name=self._region, verify=self._ssl_verify)
             if json_logging:
                 log_helper.setup(log_level, boto_level=boto_level, RequestType='ContainerInit')
             else:


### PR DESCRIPTION
This pull requests enables users to turn off certificate verification or pass a custom CA bundle path to the boto3 clients used for `lambda`, `events` and `logs`.  See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client for details.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
