### PR TITLE
Continuation of ssl verification modifications for use in non-polling mode

### DIFF
--- a/crhelper/resource_helper.py
+++ b/crhelper/resource_helper.py
@@ -239,7 +239,7 @@ class CfnResource(object):
         }
         if status:
             response_body.update({'Status': status, 'Reason': reason})
-        send_response(self._response_url, response_body)
+        send_response(self._response_url, response_body, self._ssl_verify)
 
     def init_failure(self, error):
         self._init_failed = error

--- a/crhelper/utils.py
+++ b/crhelper/utils.py
@@ -12,7 +12,7 @@ from urllib.parse import urlsplit, urlunsplit
 logger = logging.getLogger(__name__)
 
 
-def _send_response(response_url: AnyStr, response_body: AnyStr, ssl_verify: Union[bool, AnyStr, None] = True):
+def _send_response(response_url: AnyStr, response_body: AnyStr, ssl_verify: Union[bool, AnyStr] = True):
     try:
         json_response_body = json.dumps(response_body)
     except Exception as e:

--- a/crhelper/utils.py
+++ b/crhelper/utils.py
@@ -30,7 +30,7 @@ def _send_response(response_url: AnyStr, response_body: AnyStr, ssl_verify: Unio
     if isinstance(ssl_verify, str) and path.exists(ssl_verify):
         ctx.load_verify_locations(cafile=ssl_verify)
     else:
-        logger.warning("Cert path {} does not exist!.  Falling back to build in system cafile.".format(ssl_verify))
+        logger.warning("Cert path {0} does not exist!.  Falling back to using system cafile.".format(ssl_verify))
     if ssl_verify is False:
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE

--- a/crhelper/utils.py
+++ b/crhelper/utils.py
@@ -1,14 +1,18 @@
 from __future__ import print_function
+
 import json
 import logging as logging
+import ssl
 import time
-from urllib.parse import urlsplit, urlunsplit
 from http.client import HTTPSConnection
+from os import path
+from typing import Union, AnyStr
+from urllib.parse import urlsplit, urlunsplit
 
 logger = logging.getLogger(__name__)
 
 
-def _send_response(response_url, response_body):
+def _send_response(response_url: AnyStr, response_body: AnyStr, ssl_verify: Union[bool, AnyStr, None] = True):
     try:
         json_response_body = json.dumps(response_body)
     except Exception as e:
@@ -22,9 +26,18 @@ def _send_response(response_url, response_body):
     split_url = urlsplit(response_url)
     host = split_url.netloc
     url = urlunsplit(("", "", *split_url[2:]))
+    ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    if isinstance(ssl_verify, str) and path.exists(ssl_verify):
+        ctx.load_verify_locations(cafile=ssl_verify)
+    else:
+        logger.warning("Cert path {} does not exist!.  Falling back to build in system cafile.".format(ssl_verify))
+    if ssl_verify is False:
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+    # If ssl_verify is True dont modify the context in any way.
     while True:
         try:
-            connection = HTTPSConnection(host)
+            connection = HTTPSConnection(host, context=ctx)
             connection.request(method="PUT", url=url, body=json_response_body, headers=headers)
             response = connection.getresponse()
             logger.info("CloudFormation returned status code: {}".format(response.reason))

--- a/crhelper/utils.py
+++ b/crhelper/utils.py
@@ -27,10 +27,11 @@ def _send_response(response_url: AnyStr, response_body: AnyStr, ssl_verify: Unio
     host = split_url.netloc
     url = urlunsplit(("", "", *split_url[2:]))
     ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
-    if isinstance(ssl_verify, str) and path.exists(ssl_verify):
-        ctx.load_verify_locations(cafile=ssl_verify)
-    else:
-        logger.warning("Cert path {0} does not exist!.  Falling back to using system cafile.".format(ssl_verify))
+    if isinstance(ssl_verify, str):
+        if path.exists(ssl_verify):
+            ctx.load_verify_locations(cafile=ssl_verify)
+        else:
+            logger.warning("Cert path {0} does not exist!.  Falling back to using system cafile.".format(ssl_verify))
     if ssl_verify is False:
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,6 @@ import json
 from unittest.mock import patch, Mock, ANY
 from crhelper import utils
 import unittest
-import ssl
 
 
 class TestLogHelper(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,8 @@
 import json
-from unittest.mock import patch, Mock
+from unittest.mock import patch, Mock, ANY
 from crhelper import utils
 import unittest
+import ssl
 
 
 class TestLogHelper(unittest.TestCase):
@@ -10,7 +11,7 @@ class TestLogHelper(unittest.TestCase):
     @patch('crhelper.utils.HTTPSConnection', autospec=True)
     def test_send_succeeded_response(self, https_connection_mock):
         utils._send_response(self.TEST_URL, {})
-        https_connection_mock.assert_called_once_with("test_url")
+        https_connection_mock.assert_called_once_with("test_url", context=ANY)
         https_connection_mock.return_value.request.assert_called_once_with(
             body='{}',
             headers={"content-type": "", "content-length": "2"},
@@ -21,7 +22,7 @@ class TestLogHelper(unittest.TestCase):
     @patch('crhelper.utils.HTTPSConnection', autospec=True)
     def test_send_failed_response(self, https_connection_mock):
         utils._send_response(self.TEST_URL, Mock())
-        https_connection_mock.assert_called_once_with("test_url")
+        https_connection_mock.assert_called_once_with("test_url", context=ANY)
         response = json.loads(https_connection_mock.return_value.request.call_args[1]["body"])
         expected_body = '{"Status": "FAILED", "Data": {}, "Reason": "' + response["Reason"] + '"}'
         https_connection_mock.return_value.request.assert_called_once_with(


### PR DESCRIPTION
*Description of changes:*
In #46 I updated the logic for polling mode but did not update the logic for non-polling mode.  When in this mode, it appears that crhelper.util's `_send_response` function will call CFN directly.  This extends the existing ssl_verify argument passed in from the initial entry point in resource_helper.py to the HTTPSConnection's SSLContext.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
