### PR TITLE
Fix README markdown code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ particular CloudFormation event
 
 Install into the root folder of your lambda function
 
-```json
+```shell
 cd my-lambda-function/
 pip install crhelper -t .
 ```


### PR DESCRIPTION
*Description of changes:*

The set of shell instructions were in a code block marked as `json` so it renders as broken JSON. It should be `shell`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
