### PR TITLE
Fix Markdown type from yaml to json

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ in 2 minutes. Once complete either return a PhysicalResourceID or `True` to have
 deleted and a response sent back to CloudFormation. If you use polling the following additional IAM policy must be 
 attached to the function's IAM role:
 
-```yaml
+```json
 {
   "Version": "2012-10-17",
   "Statement": [


### PR DESCRIPTION
*Description of changes:*

In the same vein as #55 this changes a JSON code block from being set as a `yaml` markdown code block to a `json` one.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.