### PR TITLE
fix: handle plural forms for schedule expression unit correctly

### DIFF
--- a/crhelper/resource_helper.py
+++ b/crhelper/resource_helper.py
@@ -266,9 +266,10 @@ class CfnResource(object):
         return sid
 
     def _put_rule(self):
+        schedule_unit = 'minutes' if self._polling_interval != 1 else 'minute'
         response = self._events_client.put_rule(
             Name=self._event['LogicalResourceId'] + self._rand_string(8),
-            ScheduleExpression='rate({} minutes)'.format(self._polling_interval),
+            ScheduleExpression='rate({} {})'.format(self._polling_interval, schedule_unit),
             State='ENABLED',
         )
         return response["RuleArn"]


### PR DESCRIPTION
*Issue:*

Setting polling interval to **1** minute:

```python
helper = CfnResource(polling_interval=1)
```

causes an error during polling setup:

```
An error occurred (ValidationException) when calling the PutRule operation: Parameter ScheduleExpression is not valid. 
```

*Description of changes:*

time unit for ScheduleExpression parameter of Events PutRule API call is expected
to respect plural forms of english language, known as `nplurals=2; plural=(n != 1);`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
