### PR TITLE
add retry for cfn response module

### DIFF
--- a/crhelper/utils.py
+++ b/crhelper/utils.py
@@ -49,7 +49,7 @@ def _send_response(response_url: AnyStr, response_body: AnyStr, ssl_verify: Unio
                 success = True
             except Exception as e:
                 retry_count += 1
-                logger.error("Unexpected failure sending response to CloudFormation {}. Retrying in 5 seconds...".format(e), exc_info=True)
+                logger.error("Unexpected failure sending response to CloudFormation {}. Retrying in 2 seconds...".format(e), exc_info=True)
                 time.sleep(2)
         if success:
             break

--- a/crhelper/utils.py
+++ b/crhelper/utils.py
@@ -10,7 +10,7 @@ from typing import Union, AnyStr
 from urllib.parse import urlsplit, urlunsplit
 
 logger = logging.getLogger(__name__)
-
+MAX_RETRIES = 5  # Maximum number of retries
 
 def _send_response(response_url: AnyStr, response_body: AnyStr, ssl_verify: Union[bool, AnyStr] = None):
     try:
@@ -36,13 +36,23 @@ def _send_response(response_url: AnyStr, response_body: AnyStr, ssl_verify: Unio
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
     # If ssl_verify is True or None dont modify the context in any way.
+
     while True:
-        try:
-            connection = HTTPSConnection(host, context=ctx)
-            connection.request(method="PUT", url=url, body=json_response_body, headers=headers)
-            response = connection.getresponse()
-            logger.info("CloudFormation returned status code: {}".format(response.reason))
+        retry_count = 0
+        success = False
+        while retry_count < MAX_RETRIES and not success:
+            try:
+                connection = HTTPSConnection(host, context=ctx)
+                connection.request(method="PUT", url=url, body=json_response_body, headers=headers)
+                response = connection.getresponse()
+                logger.info("CloudFormation returned status code: {}".format(response.reason))
+                success = True
+            except Exception as e:
+                retry_count += 1
+                logger.error("Unexpected failure sending response to CloudFormation {}. Retrying in 5 seconds...".format(e), exc_info=True)
+                time.sleep(2)
+        if success:
             break
-        except Exception as e:
-            logger.error("Unexpected failure sending response to CloudFormation {}".format(e), exc_info=True)
+        else:
+            logger.error("Maximum retries reached. Unable to send response to CloudFormation.")
             time.sleep(5)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import patch, Mock, ANY
+from unittest.mock import patch, Mock, ANY, MagicMock
 from crhelper import utils
 import unittest
 import ssl
@@ -61,3 +61,29 @@ class TestLogHelper(unittest.TestCase):
         utils._send_response(self.TEST_URL, {}, ssl_verify='/invalid/path/to/ca')
         https_connection_mock.assert_called_once_with("test_url", context=ANY)
         ctx_mock.load_verify_locations.assert_not_called()
+
+
+    @patch('crhelper.utils.logger')
+    @patch('crhelper.utils.HTTPSConnection')
+    def test_send_response_retry(self, mock_https_connection, mock_logger):
+        # Mock the behavior of HTTPSConnection to fail on the first two attempts
+        mock_connection = mock_https_connection.return_value
+        mock_connection.getresponse.side_effect = [
+            Exception("Unexpected failure sending response to CloudFormation"),
+            Exception("Unexpected failure sending response to CloudFormation"), MagicMock(reason="OK")]
+
+        # Call the code under test
+        response_url = "https://example.com/response"
+        response_body = {"Status": "SUCCESS", "Data": {"Message": "Test message"}}
+        ssl_verify = True
+        utils._send_response(response_url, response_body, ssl_verify)
+
+        # Assert that the logger was called with the expected error and info messages
+        self.assertEqual(mock_logger.error.call_count, 2)
+        self.assertEqual(mock_logger.info.call_count, 1)
+
+        # Assert that the HTTPSConnection was called the expected number of times
+        self.assertEqual(mock_https_connection.call_count, 3)
+
+        # Assert that the function retried the expected number of times
+        self.assertEqual(mock_connection.getresponse.call_count, 3)


### PR DESCRIPTION
*Issue #, if available:*
Add Retry for CFN response module.
*Description of changes:*
Adds a max retry of 5 times for all error if cfn module fails to send response to CFN.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
